### PR TITLE
Made some changes, to work in debate-map's k8 cluster

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -18,7 +18,11 @@ RUN apt-get update && apt-get install -y \
             net-tools && \
             apt-get upgrade
 WORKDIR /opt
-RUN     cd /opt ; set -x ; git clone -b $GITBRANCH https://github.com/$GITREPO.git
+
+# copy files needed for pip-install process
+COPY ./pyproject.toml /opt/hyperknowledge/pyproject.toml
+COPY ./setup.cfg /opt/hyperknowledge/setup.cfg
+
 WORKDIR /opt/hyperknowledge
 ENV LC_ALL="C.UTF-8"
 ENV LC_CTYPE="C.UTF-8"
@@ -27,8 +31,20 @@ RUN python3 -mvirtualenv venv && \
     . venv/bin/activate && \
     pip install --upgrade pip && \
     pip install -e .
-CMD cd /opt/hyperknowledge && . venv/bin/activate && \
-    python scripts/initial_setup.py --app_name HyperKnowledge --host postgres -p postgres --no-create-development --no-create-test --store-password && \
+
+# copy files needed for setup and running
+COPY ./deploy /opt/hyperknowledge/deploy
+COPY ./hyperknowledge /opt/hyperknowledge/hyperknowledge
+COPY ./scripts /opt/hyperknowledge/scripts
+
+# placed late, so that changed values (eg. from Tilt) don't cause earlier commands to rerun
+ARG postgres_host=postgres
+
+# CMD can't insert values directly from an ARG (run-time vs build-time), so store it in an ENV
+ENV postgres_host_env=${postgres_host}
+
+CMD . venv/bin/activate && \
+    python scripts/initial_setup.py --app_name HyperKnowledge --host ${postgres_host_env} -p postgres --no-create-development --no-create-test --store-password && \
     python scripts/db_updater.py -d production init && \
     python scripts/db_updater.py -d production deploy && \
     uvicorn --host 0.0.0.0 hyperknowledge.eventdb.server:app

--- a/docker/server/Dockerfile.dockerignore
+++ b/docker/server/Dockerfile.dockerignore
@@ -1,0 +1,16 @@
+# Ignore everything
+*
+
+# Allow these files and directories
+!/deploy
+!/hyperknowledge
+!/scripts
+!/pyproject.toml
+!/setup.cfg
+
+# Ignore unnecessary files inside allowed directories
+# This should go after the allowed directories
+**/*~
+**/*.log
+**/.DS_Store
+**/Thumbs.db

--- a/scripts/initial_setup.py
+++ b/scripts/initial_setup.py
@@ -50,7 +50,7 @@ def get_conn_params(host="localhost", user=None, password=None, sudo=None, **kwa
         user = user or "postgres"
         sudo = True if sudo is None and password is None else sudo or False
     try:
-        # try without passwordord
+        # try without password
         test_db_exists(
             "postgres", user=user, host=host, password=password, sudo=sudo, **kwargs
         )


### PR DESCRIPTION
* Made some changes allowing for easy passing of the postgres host to the "initial_setup.py" script. (eg. "hk-postgres.default.svc", as seen in debate-map's kubernetes cluster)
* Added a docker-ignore file for the "server" dockerfile, so that changes to unrelated files do not break Docker's cache.
* Fixed typo in initial_setup.py.